### PR TITLE
Fix packaging

### DIFF
--- a/mbx
+++ b/mbx
@@ -124,6 +124,7 @@ package() {
   git fetch --tags --progress $url --depth 1 +refs/heads/*:refs/remotes/origin/* > /dev/null
   git config remote.origin.url $url
   git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/*
+  git checkout $tag
 
   cd $CUR
 


### PR DESCRIPTION
Fix packaging (debian packages tested so far)

Tested on Ubuntu 22:

````
$ sudo ./mbx package $REPO migrate-vmw-to-kvm debian
MonkeyBox 🐵 v0.4
This feature likely broken, run at your own risk
....
....
+ mv ../cloudstack-agent_4.19.0.0-SNAPSHOT_all.deb ../cloudstack-common_4.19.0.0-SNAPSHOT_all.deb ../cloudstack-docs_4.19.0.0-SNAPSHOT_all.deb ../cloudstack-integration-tests_4.19.0.0-SNAPSHOT_all.deb ../cloudstack-management_4.19.0.0-SNAPSHOT_all.deb ../cloudstack-marvin_4.19.0.0-SNAPSHOT_all.deb ../cloudstack-ui_4.19.0.0-SNAPSHOT_all.deb ../cloudstack-usage_4.19.0.0-SNAPSHOT_all.deb /jenkins
++ ls cloudstack-agent_4.19.0.0-SNAPSHOT_all.deb cloudstack-common_4.19.0.0-SNAPSHOT_all.deb cloudstack-docs_4.19.0.0-SNAPSHOT_all.deb cloudstack-integration-tests_4.19.0.0-SNAPSHOT_all.deb cloudstack-management_4.19.0.0-SNAPSHOT_all.deb cloudstack-marvin_4.19.0.0-SNAPSHOT_all.deb cloudstack-ui_4.19.0.0-SNAPSHOT_all.deb cloudstack-usage_4.19.0.0-SNAPSHOT_all.deb
+ for pkg in '$(ls cloud*.deb)'
+ cp cloudstack-agent_4.19.0.0-SNAPSHOT_all.deb /output
+ for pkg in '$(ls cloud*.deb)'
+ cp cloudstack-common_4.19.0.0-SNAPSHOT_all.deb /output
+ for pkg in '$(ls cloud*.deb)'
+ cp cloudstack-docs_4.19.0.0-SNAPSHOT_all.deb /output
+ for pkg in '$(ls cloud*.deb)'
+ cp cloudstack-integration-tests_4.19.0.0-SNAPSHOT_all.deb /output
+ for pkg in '$(ls cloud*.deb)'
+ cp cloudstack-management_4.19.0.0-SNAPSHOT_all.deb /output
+ for pkg in '$(ls cloud*.deb)'
+ cp cloudstack-marvin_4.19.0.0-SNAPSHOT_all.deb /output
+ for pkg in '$(ls cloud*.deb)'
+ cp cloudstack-ui_4.19.0.0-SNAPSHOT_all.deb /output
+ for pkg in '$(ls cloud*.deb)'
+ cp cloudstack-usage_4.19.0.0-SNAPSHOT_all.deb /output
Packages can be found at /export/testing/builds/migrate-vmw-to-kvm/debian
builder-30e553fc-3709-11ee-884c-978c216195bc
builder-30e553fc-3709-11ee-884c-978c216195bc
````

Fixes #18 