### PR TITLE
fix launch on different monkeynet subnet

### DIFF
--- a/mbx
+++ b/mbx
@@ -534,9 +534,10 @@ deploy() {
   fi
 
   envsubst < $ROOT/marvin/$hypervisor.cfg > $ROOT/boxes/$env/marvin.cfg
-  if [[ "$monkeynet_gw" != "172.20.0.1" ]]; then
-    sed -i "s/172\.20\.0\.1/$monkeynet_gw/g" $ROOT/boxes/$env/marvin.cfg
-  fi
+    if [[ "$monkeynet_gw" != "172.20.0.1" ]]; then
+      monkeynet_gw_prefix=$(echo "$monkeynet_gw" | awk -F. '{print $1"."$2"."$3}')
+      sed -i "s/172\.20\.0\./$monkeynet_gw_prefix\./g" $ROOT/boxes/$env/marvin.cfg
+    fi
   echo "VMs deployed and marvin config generated, to launch zone run:"
   echo "  mbx launch $env"
 }


### PR DESCRIPTION
Replacing `172.20.0.1` wasn't enough and the launch was failing. Replace `172.20.0` instead.

```
            "name": "management.network.cidr",
            "value": "172.20.0.0/16"
```